### PR TITLE
make install時に入れるべきファイルリストからCollisionLinkPair.hが抜けている

### DIFF
--- a/src/Body/CMakeLists.txt
+++ b/src/Body/CMakeLists.txt
@@ -99,6 +99,7 @@ set(headers
   BodyState.h
   exportdecl.h
   gettext.h
+	CollisionLinkPair.h
   )
 
 


### PR DESCRIPTION
SamplePlugin1をManualMakefileを使って外部プラグインとしてインストールしようとした際,
# include<cnoid/BodyItem>でCollisionLincPair.hが見つからないとエラーが出ました．

CollisionLinkPair.hがmake install時で入れるべきファイルリストから抜けているようでしたので
set( headers ...
でCollisionLinkPair.hを追加しました．
