### PR TITLE
set initaializeInterpolator to true

### DIFF
--- a/src/PoseSeqPlugin/PoseSeqInterpolator.cpp
+++ b/src/PoseSeqPlugin/PoseSeqInterpolator.cpp
@@ -1563,7 +1563,7 @@ bool PSIImpl::update()
     }
     for(LinkInfoMap::iterator p = ikLinkInfos.begin(); p != ikLinkInfos.end(); ++p){
         LinkInfo& info = p->second;
-        initializeInterpolation<6, LinkSample, false>(info.samples);
+        initializeInterpolation<6, LinkSample, true>(info.samples);
         info.iter = info.samples.begin();
         if(info.isFootLink){
             initializeInterpolation<1, LinkZSample, false>(info.zSamples);


### PR DESCRIPTION
あまりちゃんと分かっていないんですが，
ここで補間方法を決定しているんですが，デフォルトは位置速度のみを連続するcubic-connection
ですが，これだとZMPが連続にならずに，ここをminjerkにしたら，そこそこZMPが連続になりました．

まだ，最終的に確認はとれていないですが，とりあえずPRにしておきますので，なにかご教示ありましたら
宜しくお願い致します．