### PR TITLE
角運動量ヤコビアンの計算を実装

### DIFF
--- a/src/Body/Jacobian.cpp
+++ b/src/Body/Jacobian.cpp
@@ -135,4 +135,93 @@ void calcCMJacobian(const BodyPtr& body, Link* base, Eigen::MatrixXd& J)
             dp(1), -dp(0),    0.0;
     }
 }
+
+/**
+   @brief compute Angular Momentum Jacobian
+   @param base link fixed to the environment
+   @param H Angular Momentum Jacobian
+   @note Link::wc must be computed by calcCM() before calling
+*/
+void calcAngularMomentumJacobian(const BodyPtr& body, Link* base, Eigen::MatrixXd& H)
+{
+
+    // prepare subm, submwc
+
+    const int nj = body->numJoints();
+    std::vector<SubMass> subMasses(body->numLinks());
+    Link* rootLink = body->rootLink();
+
+    MatrixXd M;
+    calcCMJacobian( body, base, M );
+    M = M.block(0,0, 3,nj) * body->mass();
+
+    JointPath path;
+    if(!base){
+        calcSubMass(rootLink, subMasses);
+        H.resize(3, nj + 6);
+
+    } else {
+        path.setPath(rootLink, base);
+        Link* skip = path.joint(0);
+        SubMass& sub = subMasses[skip->index()];
+        sub.m = rootLink->m();
+        sub.mwc = rootLink->m() * rootLink->wc();
+            
+        for(Link* child = rootLink->child(); child; child = child->sibling()){
+            if(child != skip){
+                calcSubMass(child, subMasses);
+                subMasses[skip->index()] += subMasses[child->index()];
+            }
+        }
+            
+        // assuming there is no branch between base and root
+        for(int i=1; i < path.numJoints(); i++){
+            Link* joint = path.joint(i);
+            const Link* parent = joint->parent();
+            SubMass& sub = subMasses[joint->index()];
+            sub.m = parent->m();
+            sub.mwc = parent->m() * parent->wc();
+            sub += subMasses[parent->index()];
+        }
+            
+        H.resize(3, nj);
+    }
+
+    // compute Jacobian
+    std::vector<int> sgn(nj, 1);
+    for(int i=0; i < path.numJoints(); i++){
+        sgn[path.joint(i)->jointId()] = -1;
+    }
+
+    for(int i=0; i < nj; ++i){
+        Link* joint = body->joint(i);
+        if(joint->isRotationalJoint()){
+            const Vector3 omega = sgn[joint->jointId()] * joint->R() * joint->a();
+            const SubMass& sub = subMasses[joint->index()];
+            const Vector3 Mcol = M.col(joint->jointId());
+            const Vector3 dp = (sub.mwc/sub.m).cross(Mcol) + sub.Iw * omega;
+            H.col(joint->jointId()) = dp;
+        } else {
+            std::cerr << "calcAngularMomentumJacobian() : unsupported jointType("
+                      << joint->jointType() << std::endl;
+        }
+    }
+
+
+    if(!base){
+        const int c = nj;
+        H.block(0, c, 3, 3).setIdentity();
+
+        Vector3 cm = body->calcCenterOfMass();
+        Matrix3d cm_cross;
+        cm_cross <<
+            0.0,  -cm(2), cm(1),
+            cm(2),    0.0,  -cm(0),
+            -cm(1), cm(0),    0.0;
+        H -= cm_cross * M;
+
+    }
+    
+}
+
 }

--- a/src/Body/Jacobian.h
+++ b/src/Body/Jacobian.h
@@ -11,6 +11,8 @@ namespace cnoid {
 
 CNOID_EXPORT void calcCMJacobian(const BodyPtr& body, Link* base, Eigen::MatrixXd& J);
 
+CNOID_EXPORT void calcAngularMomentumJacobian(const BodyPtr& body, Link* base, Eigen::MatrixXd& H);
+
 template<int elementMask, int rowOffset, int colOffset, bool useTargetLinkLocalPos>
 void setJacobian(const JointPath& path, Link* targetLink, const Vector3& targetLinkLocalPos,
                  MatrixXd& out_J) {


### PR DESCRIPTION
#8 で提案していた角運動量ヤコビアンの計算を実装しました．

SubMass：慣性テンソルを追加
calcSubMass()：慣性テンソルの計算を追加

calcAngularMomentumJacobian()：角運動量ヤコビアンの計算
　使い方：基本的にcalcCMJacobianと同じでbodyと基準のリンク，計算したヤコビアンを代入する変数を引数とする
　第2引数がNULLの場合，重心周りの角運動量ヤコビアンを返す

Body::clacTotalMomentum()を使って求めた角運動量と，calcAngularMomentunJacobian()を使って求めた角運動量を原点周りに直した値が一致することを確認しました．
