### PR TITLE
add common setting for python plugin

### DIFF
--- a/src/Base/python/CMakeLists.txt
+++ b/src/Base/python/CMakeLists.txt
@@ -38,3 +38,5 @@ add_cnoid_python_module(PyBase
 )
 
 target_link_libraries(PyBase CnoidPyBase)
+
+apply_common_setting_for_library(CnoidPyBase)

--- a/src/Python/CMakeLists.txt
+++ b/src/Python/CMakeLists.txt
@@ -21,3 +21,4 @@ add_cnoid_library(${target} SHARED ${sources} ${headers})
 
 target_link_libraries(${target} ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARY})
 
+apply_common_setting_for_library(${target} "${headers}")


### PR DESCRIPTION
#10 を行ってみましたが,私の環境だと

```
choreonoid --python samples/python/ShakeBodies.py share/project/PA10Pickup.cnoid
```

を実行すると

```
Executing python script file "sample/python/ShakeBodies.py" ...
Failed to run the python script file.
Traceback (most recent call last):
  File "sample/python/ShakeBodies.py", line 2, in <module>
    from cnoid.Util import *
ImportError: libCnoidPython.so: 共有オブジェクトファイルを開けません: そのようなファイルやディレクトリはありません
```

といったエラーがでてしまいました.
とりあえずlibCnoidPython.soとlibCnoidPyBase.soをそれらしいところにインストールするようにcmakeを書き換えてみると上手くいったのですが，これで良かったでしょうか?それとも私の環境の設定が悪い可能性があるでしょうか?
