### PR TITLE
hrpsysシーケンスファイルのwaistファイルの保存関数の修正

### DIFF
--- a/src/Body/BodyMotionUtil.cpp
+++ b/src/Body/BodyMotionUtil.cpp
@@ -244,7 +244,7 @@ bool cnoid::saveHrpsysSeqFileSet(BodyMotion& motion, BodyPtr body, const std::st
     if(motion.jointPosSeq()->saveAsPlainFormat(
            getNativePathString(filesystem::change_extension(orgpath, ".pos"))) &&
            
-       motion.linkPosSeq()->saveTopPartAsPlainMatrixFormat(
+       motion.linkPosSeq()->saveTopPartAsPosAndRPYFormat(
            getNativePathString(filesystem::change_extension(orgpath, ".waist"))) &&
            
        saveRootLinkAttAsRpyFormat(

--- a/src/Util/MultiSE3Seq.cpp
+++ b/src/Util/MultiSE3Seq.cpp
@@ -117,12 +117,12 @@ bool MultiSE3Seq::saveTopPartAsPlainMatrixFormat(const std::string& filename)
                 os << " " << x.translation()[j];
             }
 
-            Vector3 rpy(rpyFromRot(Matrix3(base[i].rotation())));
+            Vector3 rpy(rpyFromRot(Matrix3(x.rotation())));
             for(int j=0; j < 3; ++j){
                 if(fabs(rpy[j]) < 1.0e-14){
                     rpy[j] = 0.0;
                 }
-                os << " " << rpy[i];
+                os << " " << rpy[j];
             }
 
             // Matrix3 R(x.rotation());

--- a/src/Util/MultiSE3Seq.cpp
+++ b/src/Util/MultiSE3Seq.cpp
@@ -116,7 +116,49 @@ bool MultiSE3Seq::saveTopPartAsPlainMatrixFormat(const std::string& filename)
             for(int j=0; j < 3; ++j){
                 os << " " << x.translation()[j];
             }
+            Matrix3 R(x.rotation());
+            for(int j=0; j < 3; ++j){
+                for(int k=0; k < 3; ++k){
+                    double m = R(j, k);
+                    if(fabs(m) < 1.0e-14){
+                        m = 0.0;
+                    }
+                    os << " " << m;
+                }
+            }
+            os << " 0 0 0 0 0 0"; // velocity elements (dv, omega)
+            os << "\n";
+        }
 
+        return true;
+    }
+
+    return false;
+}
+
+bool MultiSE3Seq::saveTopPartAsPosAndRPYFormat(const std::string& filename)
+{
+    clearSeqMessage();
+    boost::format f("%1$.4f");
+    const int nFrames = numFrames();
+
+    if(nFrames > 0 && numParts() > 0){
+
+        ofstream os(filename.c_str());
+        if(!os){
+            addSeqMessage(filename + " cannot be opened.");
+            return false;
+        }
+
+        const double r = frameRate();
+
+        Part base = part(0);
+        for(int i=0; i < nFrames; ++i){
+            os << (f % (i / r));
+            const SE3& x = base[i];
+            for(int j=0; j < 3; ++j){
+                os << " " << x.translation()[j];
+            }
             Vector3 rpy(rpyFromRot(Matrix3(x.rotation())));
             for(int j=0; j < 3; ++j){
                 if(fabs(rpy[j]) < 1.0e-14){
@@ -124,18 +166,6 @@ bool MultiSE3Seq::saveTopPartAsPlainMatrixFormat(const std::string& filename)
                 }
                 os << " " << rpy[j];
             }
-
-            // Matrix3 R(x.rotation());
-            // for(int j=0; j < 3; ++j){
-            //     for(int k=0; k < 3; ++k){
-            //         double m = R(j, k);
-            //         if(fabs(m) < 1.0e-14){
-            //             m = 0.0;
-            //         }
-            //         os << " " << m;
-            //     }
-            // }
-            // os << " 0 0 0 0 0 0"; // velocity elements (dv, omega)
             os << "\n";
         }
 

--- a/src/Util/MultiSE3Seq.cpp
+++ b/src/Util/MultiSE3Seq.cpp
@@ -116,17 +116,26 @@ bool MultiSE3Seq::saveTopPartAsPlainMatrixFormat(const std::string& filename)
             for(int j=0; j < 3; ++j){
                 os << " " << x.translation()[j];
             }
-            Matrix3 R(x.rotation());
+
+            Vector3 rpy(rpyFromRot(Matrix3(base[i].rotation())));
             for(int j=0; j < 3; ++j){
-                for(int k=0; k < 3; ++k){
-                    double m = R(j, k);
-                    if(fabs(m) < 1.0e-14){
-                        m = 0.0;
-                    }
-                    os << " " << m;
+                if(fabs(rpy[j]) < 1.0e-14){
+                    rpy[j] = 0.0;
                 }
+                os << " " << rpy[i];
             }
-            os << " 0 0 0 0 0 0"; // velocity elements (dv, omega)
+
+            // Matrix3 R(x.rotation());
+            // for(int j=0; j < 3; ++j){
+            //     for(int k=0; k < 3; ++k){
+            //         double m = R(j, k);
+            //         if(fabs(m) < 1.0e-14){
+            //             m = 0.0;
+            //         }
+            //         os << " " << m;
+            //     }
+            // }
+            // os << " 0 0 0 0 0 0"; // velocity elements (dv, omega)
             os << "\n";
         }
 

--- a/src/Util/MultiSE3Seq.h
+++ b/src/Util/MultiSE3Seq.h
@@ -34,6 +34,7 @@ public:
 
     bool loadPlainMatrixFormat(const std::string& filename);
     bool saveTopPartAsPlainMatrixFormat(const std::string& filename);
+    bool saveTopPartAsPosAndRPYFormat(const std::string& filename);
 
 protected:
     virtual SE3 defaultValue() const { return SE3(Vector3::Zero(), Quat::Identity()); }


### PR DESCRIPTION
hrpsysシーケンスファイルのwaistファイルの記述形式を修正しました．

修正した理由は
- hrpsys-baseの場合
  http://fkanehiro.github.io/hrpsys-base/dd/d91/SequencePlayer.html
  にもあるとおりルートリンクの位置姿勢の記述形式は「TimeStamp X Y Z Roll Pitch Yaw」
- GRXのhrpsysの場合
  GRXのマニュアルを参照する限りだとhrpsys-baseと同じ記述形式

である一方
- choreonoidの場合
  「TimeStamp X Y Z 姿勢行列要素(0,0) 姿勢行列要素(0,1) 姿勢行列要素(0,2) ..... 姿勢行列要素(2,2) 角速度」

のように姿勢をRPYではなく行列形式で記述するなっていたからです．

この様な実装になっているのは,hrpsys-baseとGRXのhrpsys以外のhrpsysシーケンスファイルを読み込めるシステムが存在するということでしょうか?
もしそうでしたら，今回のPRはRPYでのみ出力するようにしておりますので,共存できるように適当にマージしていただいて問題ありません．
