### PR TITLE
fix AISTSimulator store crash and CMakeLists

### DIFF
--- a/src/BodyPlugin/AISTSimulatorItem.cpp
+++ b/src/BodyPlugin/AISTSimulatorItem.cpp
@@ -558,8 +558,12 @@ bool AISTSimulatorItem::store(Archive& archive)
 
 bool AISTSimulatorItemImpl::store(Archive& archive)
 {
-    archive.write("dynamicsMode", dynamicsMode.selectedSymbol());
-    archive.write("integrationMode", integrationMode.selectedSymbol());
+    if (dynamicsMode.selectedSymbol() != 0) {
+            archive.write("dynamicsMode", dynamicsMode.selectedSymbol());
+    }
+    if (integrationMode.selectedSymbol() != 0) {
+            archive.write("integrationMode", integrationMode.selectedSymbol());
+    }
     write(archive, "gravity", gravity);
     archive.write("staticFriction", staticFriction);
     archive.write("slipFriction", slipFriction);

--- a/src/SimpleControllerPlugin/CMakeLists.txt
+++ b/src/SimpleControllerPlugin/CMakeLists.txt
@@ -10,11 +10,16 @@ endif()
 # set(CMAKE_BUILD_TYPE Debug)
 
 set(target CnoidSimpleControllerPlugin)
-set(sources 
+set(sources
   SimpleControllerPlugin.cpp
   SimpleControllerItem.cpp
 )
-set(headers "")
+set(headers
+  SimpleControllerItem.h
+  SimpleController.h
+  exportdecl.h
+  gettext.h
+)
 make_gettext_mofiles(${target} mofiles)
 add_cnoid_plugin(${target} SHARED ${sources} ${headers} ${mofiles})
 target_link_libraries(${target} CnoidBodyPlugin)

--- a/src/Util/CMakeLists.txt
+++ b/src/Util/CMakeLists.txt
@@ -133,6 +133,7 @@ set(headers
   Joystick.h
   Task.h
   exportdecl.h
+  Config.h
   )
 
 include_directories(${IRRXML_INCLUDE_DIRS})


### PR DESCRIPTION
AISTシミュレータを使用している時にプロジェクトを保存するとクラッシュする問題を修正しました。

落ちているのは、src/BodyPlugin/AISTSimulatorItem.cpp の store() です。

```cpp
bool AISTSimulatorItemImpl::store(Archive& archive)
{
    archive.write("dynamicsMode", dynamicsMode.selectedSymbol());
    archive.write("integrationMode", integrationMode.selectedSymbol());
    write(archive, "gravity", gravity);
    archive.write("staticFriction", staticFriction);
    archive.write("slipFriction", slipFriction);
    archive.write("cullingThresh", contactCullingDistance);
    archive.write("contactCullingDepth", contactCullingDepth);
    archive.write("errorCriterion", errorCriterion);
    archive.write("maxNumIterations", maxNumIterations);
    archive.write("contactCorrectionDepth", contactCorrectionDepth);
    archive.write("contactCorrectionVelocityRatio",
contactCorrectionVelocityRatio);
    archive.write("kinematicWalking", isKinematicWalkingEnabled);
    archive.write("2Dmode", is2Dmode);
    return true;
}
```

dynamicsMode.selectedSymbol() が問題で、この関数の定義は以下のようになっています。

```cpp
const char* Selection::selectedSymbol() const
{
    if(selectedIndex_ >= 0){
        return symbols_[selectedIndex_].c_str();
    }
    return 0;
}
```

選択されていない場合、この関数は 0 （ヌルポインタ）を返します。
しかし、archive.write() は `const std::string&` を引数に取るので
ヌルポインタでは初期化できず実行時エラーとなってしまっていました。

Edit:  CMakeLists に抜けがある問題を合わせて修正しました。