### PR TITLE
Fix warnings

### DIFF
--- a/src/BodyPlugin/AISTSimulatorItem.cpp
+++ b/src/BodyPlugin/AISTSimulatorItem.cpp
@@ -558,8 +558,12 @@ bool AISTSimulatorItem::store(Archive& archive)
 
 bool AISTSimulatorItemImpl::store(Archive& archive)
 {
-    archive.write("dynamicsMode", dynamicsMode.selectedSymbol());
-    archive.write("integrationMode", integrationMode.selectedSymbol());
+    if (dynamicsMode.selectedSymbol() != 0) {
+            archive.write("dynamicsMode", dynamicsMode.selectedSymbol());
+    }
+    if (integrationMode.selectedSymbol() != 0) {
+            archive.write("integrationMode", integrationMode.selectedSymbol());
+    }
     write(archive, "gravity", gravity);
     archive.write("staticFriction", staticFriction);
     archive.write("slipFriction", slipFriction);

--- a/src/SimpleControllerPlugin/CMakeLists.txt
+++ b/src/SimpleControllerPlugin/CMakeLists.txt
@@ -10,11 +10,16 @@ endif()
 # set(CMAKE_BUILD_TYPE Debug)
 
 set(target CnoidSimpleControllerPlugin)
-set(sources 
+set(sources
   SimpleControllerPlugin.cpp
   SimpleControllerItem.cpp
 )
-set(headers "")
+set(headers
+  SimpleControllerItem.h
+  SimpleController.h
+  exportdecl.h
+  gettext.h
+)
 make_gettext_mofiles(${target} mofiles)
 add_cnoid_plugin(${target} SHARED ${sources} ${headers} ${mofiles})
 target_link_libraries(${target} CnoidBodyPlugin)

--- a/src/Util/CMakeLists.txt
+++ b/src/Util/CMakeLists.txt
@@ -133,6 +133,7 @@ set(headers
   Joystick.h
   Task.h
   exportdecl.h
+  Config.h
   )
 
 include_directories(${IRRXML_INCLUDE_DIRS})

--- a/src/Util/EigenTypes.h
+++ b/src/Util/EigenTypes.h
@@ -78,8 +78,8 @@ using Eigen::Isometry3d;
 typedef Eigen::Isometry3d Isometry3;
     
 class SE3 {
-    Quat q;
     Vector3 p;
+    Quat q;
 public:
     SE3() { }
     SE3(const Vector3& translation, const Quat& rotation)

--- a/src/Util/Signal.h
+++ b/src/Util/Signal.h
@@ -149,6 +149,7 @@ public:
         if(slot){
             slot->changeOrder(order);
         }
+        return *this;
     }
 };
 
@@ -160,14 +161,14 @@ public:
     ~ScopedConnection() { Connection::disconnect(); }
     void reset(const Connection& c) { Connection::disconnect(); Connection::operator=(c); }
     void disconnect() { Connection::disconnect(); }
-    bool connected() { Connection::connected(); }
+    bool connected() { return Connection::connected(); }
     void block() { Connection::block(); }
     void unblock() { Connection::unblock(); }
-    ScopedConnection& changeOrder(Order order) { Connection::changeOrder(order); }
+    ScopedConnection& changeOrder(Order order) { Connection::changeOrder(order); return *this; }
 
 private:
-    ScopedConnection(const ScopedConnection& org) { }
-    ScopedConnection& operator=(const ScopedConnection& rhs) { }
+    ScopedConnection(const ScopedConnection& org);
+    ScopedConnection& operator=(const ScopedConnection& rhs);
 };
 
 }


### PR DESCRIPTION
choreonoid ヘッダファイルにおける警告を修正しました。

1. 初期化順序の警告

コンストラクタの記述順序と初期化の順序が一致していません。
実際の初期化順序はclassで変数が宣言されている順です。混乱を招くので警告をされていました。

2. return がない関数の修正

おそらく、こちらはバグです。

3. コピーコンストラクタとデフォルト演算子の抑止方法の修正

こちらもバグです。デフォルトの演算子とコピーコンストラクタを抑止するだけなら定義する必要はありません。