### PR TITLE
Make bullet plugin work again

### DIFF
--- a/src/BulletPlugin/BulletCollisionDetector.cpp
+++ b/src/BulletPlugin/BulletCollisionDetector.cpp
@@ -586,8 +586,8 @@ void BulletCollisionDetectorImpl::detectCollisions(boost::function<void(const Co
 void BulletCollisionDetectorImpl::detectObjectCollisions(btCollisionObject* object1, btCollisionObject* object2, CollisionPair& collisionPair)
 {
     vector<Collision>& collisions = collisionPair.collisions;
-    btCollisionObjectWrapper objectWrapper1(0, object1->getCollisionShape(), object1, object1->getWorldTransform(), -1, -1);
-    btCollisionObjectWrapper objectWrapper2(0, object2->getCollisionShape(), object2, object2->getWorldTransform(), -1, -1);
+    btCollisionObjectWrapper objectWrapper1(0, object1->getCollisionShape(), object1, object1->getWorldTransform());
+    btCollisionObjectWrapper objectWrapper2(0, object2->getCollisionShape(), object2, object2->getWorldTransform());
 
     btCollisionAlgorithm* algo = collisionWorld->getDispatcher()->findAlgorithm(&objectWrapper1, &objectWrapper2);
     if (algo){

--- a/src/BulletPlugin/BulletCollisionDetector.cpp
+++ b/src/BulletPlugin/BulletCollisionDetector.cpp
@@ -586,8 +586,13 @@ void BulletCollisionDetectorImpl::detectCollisions(boost::function<void(const Co
 void BulletCollisionDetectorImpl::detectObjectCollisions(btCollisionObject* object1, btCollisionObject* object2, CollisionPair& collisionPair)
 {
     vector<Collision>& collisions = collisionPair.collisions;
+    #ifdef BT_VER_GT_282
+    btCollisionObjectWrapper objectWrapper1(0, object1->getCollisionShape(), object1, object1->getWorldTransform(), -1, -1);
+    btCollisionObjectWrapper objectWrapper2(0, object2->getCollisionShape(), object2, object2->getWorldTransform(), -1, -1);
+    #else
     btCollisionObjectWrapper objectWrapper1(0, object1->getCollisionShape(), object1, object1->getWorldTransform());
     btCollisionObjectWrapper objectWrapper2(0, object2->getCollisionShape(), object2, object2->getWorldTransform());
+    #endif
 
     btCollisionAlgorithm* algo = collisionWorld->getDispatcher()->findAlgorithm(&objectWrapper1, &objectWrapper2);
     if (algo){

--- a/src/BulletPlugin/CMakeLists.txt
+++ b/src/BulletPlugin/CMakeLists.txt
@@ -11,7 +11,7 @@ set(BULLET_DIR ${BULLET_DIR} CACHE PATH "set the top directory of the Bullet Phy
 set(BULLET_CFLAGS -DBT_USE_DOUBLE_PRECISION)
 if(UNIX)
   if(NOT BULLET_DIR)
-    FIND_PACKAGE(Bullet REQUIRED NO_MODULE)
+    FIND_PACKAGE(Bullet REQUIRED)
   else()
     set(BULLET_INCLUDE_DIRS ${BULLET_DIR}/include/bullet)
     set(BULLET_LIBRARY_DIRS ${BULLET_DIR}/lib/)

--- a/src/BulletPlugin/CMakeLists.txt
+++ b/src/BulletPlugin/CMakeLists.txt
@@ -11,12 +11,13 @@ set(BULLET_DIR ${BULLET_DIR} CACHE PATH "set the top directory of the Bullet Phy
 if(UNIX)
   if(NOT BULLET_DIR)
     PKG_CHECK_MODULES(bullet REQUIRED bullet)
+    # HACD is not included in bullet.pc, we thus have to add it ourselves.
+    LIST(APPEND ${bullet_LIBRARIES} HACD)
   else()
     set(bullet_INCLUDE_DIRS ${BULLET_DIR}/include/bullet)
     set(bullet_LIBRARY_DIRS ${BULLET_DIR}/lib/)
+    set(bullet_LIBRARIES BulletDynamics BulletCollision LinearMath HACD)
   endif()
-  # HACD is not included in bullet.pc, we thus have to add it ourselves.
-  LIST(APPEND ${bullet_LIBRARIES} HACD)
 
 elseif(MSVC)
   if(NOT BULLET_DIR)

--- a/src/BulletPlugin/CMakeLists.txt
+++ b/src/BulletPlugin/CMakeLists.txt
@@ -8,38 +8,42 @@ endif()
 #set(CMAKE_BUILD_TYPE Debug)
 
 set(BULLET_DIR ${BULLET_DIR} CACHE PATH "set the top directory of the Bullet Physics library")
-set(BULLET_CFLAGS -DBT_USE_DOUBLE_PRECISION)
 if(UNIX)
   if(NOT BULLET_DIR)
-    FIND_PACKAGE(Bullet REQUIRED)
+    PKG_CHECK_MODULES(bullet REQUIRED bullet)
   else()
-    set(BULLET_INCLUDE_DIRS ${BULLET_DIR}/include/bullet)
-    set(BULLET_LIBRARY_DIRS ${BULLET_DIR}/lib/)
+    set(bullet_INCLUDE_DIRS ${BULLET_DIR}/include/bullet)
+    set(bullet_LIBRARY_DIRS ${BULLET_DIR}/lib/)
   endif()
   # BulletConfig.cmake of version 2.82-r2704 provides a wrong name for BulletCollision,
   # so BULLET_LIBRARIES must be overwritten even if the variable is obtained from BulletConfig.cmake
-  set(BULLET_LIBRARIES BulletDynamics BulletCollision LinearMath HACD)
+  set(bullet_LIBRARIES BulletDynamics BulletCollision LinearMath HACD)
 
 elseif(MSVC)
   if(NOT BULLET_DIR)
     message(FATAL_ERROR "Please specify the directory of the Bullet Physics library to BULLET_DIR.")
   endif()
   if(BULLET_DIR)
-    set(BULLET_LIBRARIES optimized BulletCollision optimized BulletDynamics optimized LinearMath optimized HACD
+    set(bullet_LIBRARIES optimized BulletCollision optimized BulletDynamics optimized LinearMath optimized HACD
                          debug BulletCollision_Debug debug BulletDynamics_Debug debug LinearMath_Debug debug HACD_Debug)
-    set(BULLET_INCLUDE_DIRS ${BULLET_DIR}/include/bullet ${BULLET_DIR}/src ${BULLET_DIR}/Extras)
-    set(BULLET_LIBRARY_DIRS ${BULLET_DIR}/lib/)
+    set(bullet_INCLUDE_DIRS ${BULLET_DIR}/include/bullet ${BULLET_DIR}/src ${BULLET_DIR}/Extras)
+    set(bullet_LIBRARY_DIRS ${BULLET_DIR}/lib/)
   endif()
 endif()
 
-add_definitions(${BULLET_CFLAGS})
-include_directories(${BULLET_INCLUDE_DIRS})
-link_directories(${BULLET_LIBRARY_DIRS})
+add_definitions(${bullet_CFLAGS})
+
+if(${bullet_VERSION} VERSION_GREATER 2.82)
+  add_definitions(-DBT_VER_GT_282)
+endif()
+
+include_directories(${bullet_INCLUDE_DIRS})
+link_directories(${bullet_LIBRARY_DIRS})
 
 set(target CnoidBulletPlugin)
 
 if(MSVC)
-  link_directories(${BULLET_LIBRARY_DIRS}/Release)
+  link_directories(${bullet_LIBRARY_DIRS}/Release)
 endif()
 
 set(sources
@@ -56,9 +60,9 @@ QT4_WRAP_CPP(sources
 
 make_gettext_mofiles(${target} mofiles)
 add_cnoid_plugin(${target} SHARED ${sources} ${headers} ${mofiles})
-target_link_libraries(${target} CnoidBodyPlugin ${BULLET_LIBRARIES})
+target_link_libraries(${target} CnoidBodyPlugin ${bullet_LIBRARIES})
 apply_common_setting_for_plugin(${target} "${headers}")
-install_external_libraries(${BULLET_DIR}/bin ${BULLET_DIR}/lib ${BULLET_LIBRARIES})
+install_external_libraries(${BULLET_DIR}/bin ${BULLET_DIR}/lib ${bullet_LIBRARIES})
 
 if(ENABLE_PYTHON)
   add_subdirectory(python)

--- a/src/BulletPlugin/CMakeLists.txt
+++ b/src/BulletPlugin/CMakeLists.txt
@@ -15,9 +15,8 @@ if(UNIX)
     set(bullet_INCLUDE_DIRS ${BULLET_DIR}/include/bullet)
     set(bullet_LIBRARY_DIRS ${BULLET_DIR}/lib/)
   endif()
-  # BulletConfig.cmake of version 2.82-r2704 provides a wrong name for BulletCollision,
-  # so BULLET_LIBRARIES must be overwritten even if the variable is obtained from BulletConfig.cmake
-  set(bullet_LIBRARIES BulletDynamics BulletCollision LinearMath HACD)
+  # HACD is not included in bullet.pc, we thus have to add it ourselves.
+  LIST(APPEND ${bullet_LIBRARIES} HACD)
 
 elseif(MSVC)
   if(NOT BULLET_DIR)

--- a/src/BulletPlugin/python/PyBulletPlugin.cpp
+++ b/src/BulletPlugin/python/PyBulletPlugin.cpp
@@ -1,46 +1,19 @@
 /*!
- * @author Hisashi Ikari
+ * @author Hervé Audren
  */
-#include <boost/python.hpp>
 
-// This header is an "EXPLICIT" item of dependence.
-// And this items are located in the "cnoid/include" or same directory.
-// Its meaning is exposed externally. For reason, we can will be selected here.
-
-#include <cnoid/Referenced>
-#include <cnoid/Item>
-#include <cnoid/RootItem>
-#include <cnoid/WorldItem>
-
-#include "../../Base/python/PyBase.h"
 #include "../BulletSimulatorItem.h"
+#include <cnoid/PyUtil>
 
-// We recommend the use of minieigen.
 using namespace boost::python;
 using namespace cnoid;
 
-namespace cnoid
+BOOST_PYTHON_MODULE(BulletPlugin)
 {
-    /*!
-     * @brief Reference types are explicitly declare a function pointer. 
-     *        Reference types share a reference to the original(in C++).
-     *        But, it does not share the type of destination(in python).
-     *        (Reason-1. Primitive types can not be a reference type.)
-     *        (Reason-2. Minieigen create an object always.)
-     *        Therefore, we must use the setter if you want to use the python.
-     *        We will define the settings of the following variables.       
-     */
-    BOOST_PYTHON_MODULE(BulletPlugin)
-    {
         /*!
          * @brief Provides following all item types.
          */
-        class_ < BulletSimulatorItem, ref_ptr<BulletSimulatorItem>, 
-            bases<SimulatorItem>, boost::noncopyable >("BulletSimulatorItem", init<>())
-            .def("__init__", boost::python::make_constructor(&createInstance<BulletSimulatorItem>));
-
-    }
-
-}; // end of namespace 
-
-
+        class_ < BulletSimulatorItem,
+                 BulletSimulatorItemPtr,
+                 bases<SimulatorItem> >("BulletSimulatorItem");
+}


### PR DESCRIPTION
Hello,

As the Bullet Plugin was broken, I took the liberty of fixing it (Since November according to  issue #19 ).

I had to remove the old Python code (createInstance) and modify the signature of some functions to match the bullet provided by Ubuntu 14.04. I also had to remove the NO_MODULE option in the CMakeLists which completely broke the build.

In addition, I had to turn off the double precision setting, but I suspect that this is because the package shipped by Ubuntu has it turned off, and thus did not include it in the commits.

All the best,
Hervé