### PR TITLE
add gazebo ode version of python module

### DIFF
--- a/src/ODEPlugin/python/CMakeLists.txt
+++ b/src/ODEPlugin/python/CMakeLists.txt
@@ -1,6 +1,16 @@
 
 # @author Hisashi Ikari
 
-set(target PyODEPlugin)
-add_cnoid_python_module(${target} PyODEPlugin.cpp)
-target_link_libraries(${target} CnoidODEPlugin CnoidPyBase ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARY})
+if(BUILD_ODE_PLUGIN)
+  set(ode ODE)
+endif()
+if(BUILD_GAZEBO_ODE_PLUGIN)
+  set(gazebo_ode GAZEBO_ODE)
+endif()
+set(versions ${ode} ${gazebo_ode})
+
+foreach(version ${versions})
+  set(target Py${version}Plugin)
+  add_cnoid_python_module(${target} PyODEPlugin.cpp)
+  target_link_libraries(${target} Cnoid${version}Plugin CnoidPyBase ${PYTHON_LIBRARIES} ${Boost_PYTHON_LIBRARY})
+endforeach()


### PR DESCRIPTION
ENABLE_PYTHONとGAZEBO_ODEを両方有効にした場合にコンパイルエラーが出るので修正しました。