### PR TITLE
Do not try to access pseq if it's empty in KinematicFaultChecker

### DIFF
--- a/src/BodyPlugin/KinematicFaultChecker.cpp
+++ b/src/BodyPlugin/KinematicFaultChecker.cpp
@@ -440,17 +440,28 @@ int KinematicFaultCheckerImpl::checkFaults
         if(checkCollision){
 
             Link* link = body->link(0);
-            const SE3& p = pseq->at(frame, 0);
-            link->p() = p.translation();
-            link->R() = p.rotation().toRotationMatrix();
-            
+            if(!pseq->empty())
+            {
+                const SE3& p = pseq->at(frame, 0);
+                link->p() = p.translation();
+                link->R() = p.rotation().toRotationMatrix();
+            }
+            else
+            {
+                link->p() = Vector3d(0., 0., 0.);
+                link->R() = Matrix3d::Identity();
+            }
+
             body->calcForwardKinematics();
 
             for(int i=1; i < numLinks; ++i){
                 link = body->link(i);
-                const SE3& p = pseq->at(frame, i);
-                link->p() = p.translation();
-                link->R() = p.rotation().toRotationMatrix();
+                if(!pseq->empty())
+                {
+                    const SE3& p = pseq->at(frame, i);
+                    link->p() = p.translation();
+                    link->R() = p.rotation().toRotationMatrix();
+                }
             }
 
             for(int i=0; i < numLinks; ++i){


### PR DESCRIPTION
Due to another bug, choreonoid seems like it does not import the Hrpsys waist files (*.pos, *.hip). Due to this, the pseq queue is empty when doing collision checks which results in crashes described in #38 .

As both at(size_t index) and operator[] have no safety checks, attempting to access an element of an empty queue results in a SIGFPE (Because we are basically attempting to do 0 % 0 when computing the position of the element).

In this pull request, I simply added guards in the problematic section of KinematicFaultChecker, but it would maybe be a better idea to throw the appropriate exception when doing an out-of-bounds access.

Cheers,
Hervé