### PR TITLE
Correctly implement loading hip files

### DIFF
--- a/src/Body/BodyMotionUtil.cpp
+++ b/src/Body/BodyMotionUtil.cpp
@@ -166,6 +166,21 @@ bool cnoid::loadHrpsysSeqFileSet(BodyMotion& motion, const std::string& filename
         }
     }
 
+    MultiSE3SeqPtr rootLinkAttSeq;
+    filesystem::path hipFile = filesystem::change_extension(orgpath, ".hip");
+    if(filesystem::exists(hipFile) && !filesystem::is_directory(hipFile)){
+        string hipFileString = getNativePathString(hipFile);
+        rootLinkAttSeq = motion.linkPosSeq();
+        if(!rootLinkAttSeq->loadPlainRpyFormat(hipFileString)){
+            os << rootLinkAttSeq->seqMessage();
+            rootLinkAttSeq.reset();
+        } else {
+            if(hipFileString == filename){
+                loaded = true;
+            }
+        }
+    }
+
     MultiSE3SeqPtr linkPosSeq;
     filesystem::path waistFile = filesystem::change_extension(orgpath, ".waist");
     if(filesystem::exists(waistFile) && !filesystem::is_directory(waistFile)){
@@ -231,7 +246,7 @@ bool cnoid::loadHrpsysSeqFileSet(BodyMotion& motion, const std::string& filename
     if(!loaded){
         motion.setNumFrames(0);
     }
-        
+
     return loaded;
 }
 

--- a/src/Util/MultiSE3Seq.h
+++ b/src/Util/MultiSE3Seq.h
@@ -33,6 +33,7 @@ public:
     //virtual bool loadPlainFormat(const std::string& filename);
 
     bool loadPlainMatrixFormat(const std::string& filename);
+    bool loadPlainRpyFormat(const std::string& filename);
     bool saveTopPartAsPlainMatrixFormat(const std::string& filename);
 
 protected:


### PR DESCRIPTION
This pull request implements the loading of .hip files (Raw RPY notation). This is related to #38 in the sense that .hip files were not correctly loaded and triggered incorrect behaviour when no .waist files were present.

Before merging, we should decide on a correct behaviour when both .hip and .waist files are present. I think the waist file, containing more information should override the .hip file but I am not sure about it.

Another point that I would like to enhance is that now, by default, I set the translation to (0,0,0) when loading a .hip file. I think it would be better to keep the actual position, but AFAIK, this is not really possible in the current API.

Cheers,
Hervé