### PR TITLE
Fixes for Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,39 +402,41 @@ if(MSVC AND INSTALL_SDK_WITH_EXTLIBS)
 endif()
 
 
-# qt
-if(ENABLE_GUI)
-  if(NOT MSVC OR MSVC_VERSION LESS 1700)
-    find_package(Qt4 4.7.0 REQUIRED)
-    set(QT_USE_QTOPENGL TRUE)
-    set(QT_USE_QTNETWORK TRUE)
-    #set(QT_USE_QTTEST TRUE)
-    include(${QT_USE_FILE})
-    add_definitions(-DQT_NO_KEYWORDS)
-    set(QT5 FALSE)
-    
+###############
+#  Setup Qt4  #
+###############
+macro(setup_qt4)
+  find_package(Qt4 4.7.0 REQUIRED)
+  set(QT_USE_QTOPENGL TRUE)
+  set(QT_USE_QTNETWORK TRUE)
+  #set(QT_USE_QTTEST TRUE)
+  include(${QT_USE_FILE})
+  add_definitions(-DQT_NO_KEYWORDS)
+  set(QT5 FALSE)
+
+  if(MSVC)
     install_external_libraries(${QT_BINARY_DIR} ${QT_LIBRARY_DIR} ${QT_LIBRARIES})
-    if(MSVC AND INSTALL_SDK_WITH_EXTLIBS)
+    if(INSTALL_SDK_WITH_EXTLIBS)
       foreach(dir
-  	  ${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR} ${QT_QTOPENGL_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
-	install(DIRECTORY ${dir} DESTINATION ${CNOID_HEADER_SUBDIR})
+          ${QT_QTCORE_INCLUDE_DIR} ${QT_QTGUI_INCLUDE_DIR} ${QT_QTOPENGL_INCLUDE_DIR} ${QT_QTNETWORK_INCLUDE_DIR})
+        install(DIRECTORY ${dir} DESTINATION ${CNOID_HEADER_SUBDIR})
       endforeach()
     endif()
-  else()
-    if(MSVC)
-      if(CMAKE_CL_64)
-	set(CMAKE_LIBRARY_PATH "$ENV{VS110COMNTOOLS}../../../Windows\ Kits/8.0/Lib/win8/um/x64")
-      else()
-	set(CMAKE_LIBRARY_PATH "$ENV{VS110COMNTOOLS}../../../Windows\ Kits/8.0/Lib/win8/um/x86")
-      endif()
-    endif()
-    find_package(Qt5Core)
-    set(QT5 TRUE)
-    
-    add_definitions(-DQT_NO_KEYWORDS -DQT_NO_OPENGL_ES_2)
-    set(CMAKE_AUTOMOC ON)
-    set(CMAKE_INCLUDE_CURRENT_DIR ON)
-    
+  endif()
+endmacro()
+
+###############
+#  Setup Qt5  #
+###############
+macro(setup_qt5)
+  find_package(Qt5Core)
+  set(QT5 TRUE)
+
+  add_definitions(-DQT_NO_KEYWORDS -DQT_NO_OPENGL_ES_2)
+  set(CMAKE_AUTOMOC ON)
+  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+  if(MSVC)
     list(APPEND QT_INST_LIBRARIES 
       optimized Qt5Core debug Qt5Cored
       optimized Qt5Gui debug Qt5Guid
@@ -448,14 +450,38 @@ if(ENABLE_GUI)
       optimized icudt51 debug icudt51d
       # for the Qt 5.3 binary package
       general icuin52 general icuuc52 general icudt52)
-    
+
     install_external_libraries(${_qt5Core_install_prefix}/bin ${_qt5Core_install_prefix}/lib ${QT_INST_LIBRARIES})
-    if(MSVC AND INSTALL_SDK_WITH_EXTLIBS)
+
+    if(CMAKE_CL_64)
+      set(CMAKE_LIBRARY_PATH "$ENV{VS110COMNTOOLS}../../../Windows\ Kits/8.0/Lib/win8/um/x64")
+    else()
+      set(CMAKE_LIBRARY_PATH "$ENV{VS110COMNTOOLS}../../../Windows\ Kits/8.0/Lib/win8/um/x86")
+    endif()
+
+    if(INSTALL_SDK_WITH_EXTLIBS)
       foreach(dir
-  	  ${Qt5Core_INCLUDE_DIRS} ${Qt5Gui_INCLUDE_DIRS} ${Qt5OpenGL_INCLUDE_DIRS} ${Qt5Network_INCLUDE_DIRS})
-	install(DIRECTORY ${dir} DESTINATION ${CNOID_HEADER_SUBDIR})
+          ${Qt5Core_INCLUDE_DIRS} ${Qt5Gui_INCLUDE_DIRS} ${Qt5OpenGL_INCLUDE_DIRS} ${Qt5Network_INCLUDE_DIRS})
+        install(DIRECTORY ${dir} DESTINATION ${CNOID_HEADER_SUBDIR})
       endforeach()
     endif()
+  endif()
+endmacro()
+
+# qt
+if(ENABLE_GUI)
+  if(NOT MSVC OR MSVC_VERSION LESS 1700)
+    set(DEFAULT_USE_QT5 FALSE)
+  else()
+    set(DEFAULT_USE_QT5 TRUE)
+  endif()
+
+  option(USE_QT5 "Use Qt5" ${DEFAULT_USE_QT5})
+
+  if(USE_QT5)
+    setup_qt5()
+  else()
+    setup_qt4()
   endif()
 endif()
 

--- a/sample/GRobotPlugin/CMakeLists.txt
+++ b/sample/GRobotPlugin/CMakeLists.txt
@@ -19,7 +19,11 @@ set(target CnoidGRobotPlugin)
 
 make_gettext_mofiles(${target} mofiles)
 
-QT4_ADD_RESOURCES(RC_SRCS GRobotPlugin.qrc)
+if(NOT QT5)
+  QT4_ADD_RESOURCES(RC_SRCS GRobotPlugin.qrc)
+else()
+  QT5_ADD_RESOURCES(RC_SRCS GRobotPlugin.qrc)
+endif()
 
 add_cnoid_plugin(${target} SHARED
   GRobotPlugin.cpp

--- a/sample/HelloWorldPlugin/CMakeLists.txt
+++ b/sample/HelloWorldPlugin/CMakeLists.txt
@@ -10,10 +10,10 @@ if(BUILD_HELLO_WORLD_SAMPLE)
   add_cnoid_plugin(${target} SHARED HelloWorldPlugin.cpp)
   target_link_libraries(${target} CnoidBase)
   apply_common_setting_for_plugin(${target})
-endif()
 
-if(QT5)
-  qt5_use_modules(${target} Widgets)
+  if(QT5)
+    qt5_use_modules(${target} Widgets)
+  endif()
 endif()
 
 install_sample_source(HelloWorldPlugin.cpp)

--- a/sample/Sample1Plugin/CMakeLists.txt
+++ b/sample/Sample1Plugin/CMakeLists.txt
@@ -10,10 +10,10 @@ if(BUILD_SAMPLE1_SAMPLE)
   add_cnoid_plugin(${target} SHARED Sample1Plugin.cpp)
   target_link_libraries(${target} CnoidBodyPlugin)
   apply_common_setting_for_plugin(${target})
-endif()
 
-if(QT5)
-  qt5_use_modules(${target} Widgets)
+  if(QT5)
+    qt5_use_modules(${target} Widgets)
+  endif()
 endif()
 
 install_sample_source(Sample1Plugin.cpp)

--- a/src/Base/ExtensionManager.cpp
+++ b/src/Base/ExtensionManager.cpp
@@ -207,7 +207,11 @@ void ExtensionManager::manageSub(PtrHolderBase* holder)
 
 void ExtensionManager::addToolBar(ToolBar* toolBar)
 {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
     toolBar->setWindowTitle(dgettext(impl->textDomain.c_str(), toolBar->objectName().toAscii()));
+#else
+    toolBar->setWindowTitle(dgettext(impl->textDomain.c_str(), toolBar->objectName().toUtf8()));
+#endif
     manage(toolBar);
     MainWindow::instance()->addToolBar(toolBar);
 }

--- a/src/Base/python/CMakeLists.txt
+++ b/src/Base/python/CMakeLists.txt
@@ -17,9 +17,17 @@ target_link_libraries(PyQtCore
   ${Boost_PYTHON_LIBRARY}
   )
 
+if(QT5)
+  qt5_use_modules(PyQtCore Core)
+endif()
+
 add_cnoid_python_module(PyQtGui
   PyQtGui.cpp
   )
+
+if(QT5)
+  qt5_use_modules(PyQtGui Widgets)
+endif()
 
 target_link_libraries(PyQtGui
   ${QT_LIBRARIES}

--- a/src/Base/python/PyQtCore.cpp
+++ b/src/Base/python/PyQtCore.cpp
@@ -59,16 +59,25 @@ BOOST_PYTHON_MODULE(QtCore)
         .def("startTimer", &QObject::startTimer)
         .def("deleteLater", &QObject::deleteLater);
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    void (*singleShotPtr) (int, const QObject*, const char*) = &QTimer::singleShot;
+#endif
+
     class_<QTimer, QTimer*, boost::noncopyable>("QTimer")
         .def("interval", &QTimer::interval)
         .def("isActive", &QTimer::isActive)
         .def("isSingleShot", &QTimer::isSingleShot)
         .def("setInterval", &QTimer::setInterval)
-        .def("setSingleShot", &QTimer::singleShot)
+        .def("setSingleShot", &QTimer::setSingleShot)
         .def("timerId", &QTimer::timerId)
         .def("start", QTimer_start1)
         .def("start", QTimer_start2)
         .def("stop", &QTimer::stop)
-        .def("singleShot", &QTimer::singleShot).staticmethod("singleShot");
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+        .def("singleShot", &QTimer::singleShot)
+#else
+        .def("singleShot", singleShotPtr)
+#endif
+        .staticmethod("singleShot");
 }
 

--- a/src/BulletPlugin/CMakeLists.txt
+++ b/src/BulletPlugin/CMakeLists.txt
@@ -55,8 +55,11 @@ set(sources
 set(headers
   )
 
-QT4_WRAP_CPP(sources
-  )
+
+if(NOT QT5)
+  QT4_WRAP_CPP(sources
+    )
+endif()
 
 make_gettext_mofiles(${target} mofiles)
 add_cnoid_plugin(${target} SHARED ${sources} ${headers} ${mofiles})

--- a/src/MediaPlugin/CMakeLists.txt
+++ b/src/MediaPlugin/CMakeLists.txt
@@ -62,8 +62,10 @@ set(headers
 
 make_headers_public(${headers})
 
-QT4_WRAP_CPP(sources
-  )
+if(NOT QT5)
+  QT4_WRAP_CPP(sources
+    )
+endif()
 
 set(target CnoidMediaPlugin)
 make_gettext_mofiles(${target} mofiles)

--- a/src/PythonPlugin/PythonConsoleView.cpp
+++ b/src/PythonPlugin/PythonConsoleView.cpp
@@ -11,6 +11,7 @@
 #include <QBoxLayout>
 #include <QTextBlock>
 #include <QEventLoop>
+#include <QMimeData>
 #include <list>
 #include "gettext.h"
 

--- a/src/RobotAccessPlugin/CMakeLists.txt
+++ b/src/RobotAccessPlugin/CMakeLists.txt
@@ -21,7 +21,13 @@ set(headers
   )
 
 make_gettext_mofiles(${target} mofiles)
-QT4_ADD_RESOURCES(RC_SRCS RobotAccessPlugin.qrc)
+
+if(NOT QT5)
+  QT4_ADD_RESOURCES(RC_SRCS RobotAccessPlugin.qrc)
+else()
+  QT5_ADD_RESOURCES(RC_SRCS RobotAccessPlugin.qrc)
+endif()
+
 add_cnoid_plugin(${target} SHARED ${sources} ${headers} ${mofiles} ${RC_SRCS})
 target_link_libraries(${target} CnoidBodyPlugin)
 apply_common_setting_for_plugin(${target} "${headers}")


### PR DESCRIPTION
This fixes a bunch of compile-time errors when using Qt5.

There was also a possible error for Qt4 with QTimer's Python bindings: `QTimer::singleShot` was used instead of `QTimer::setSingleShot`. In Qt5, `singleShot` was also overloaded, so we're using the method that already existed in Qt4.

I also added an option to force the use of Qt5. The default behavior is still the same.