### PR TITLE
change D parameter as [0, 0, 0, 0, 0]

### DIFF
--- a/src/OpenRTMPlugin/VirtualRobotPortHandler.cpp
+++ b/src/OpenRTMPlugin/VirtualRobotPortHandler.cpp
@@ -405,7 +405,9 @@ void CameraImageOutPortHandler::initialize(Body* simBody)
         value.data.intrinsic.matrix_element[2] = u0;
         value.data.intrinsic.matrix_element[3] = fv;
         value.data.intrinsic.matrix_element[4] = v0;
-        value.data.intrinsic.distortion_coefficient.length(0);
+        value.data.intrinsic.distortion_coefficient.length(5);
+        for (int i=0; i<4; i++)
+          value.data.intrinsic.distortion_coefficient[i] = 0.0; // zero distortion is natural in simulator
         for(int i=0; i<4; i++)
             for(int j=0; j<4; j++)
                 value.data.extrinsic[i][j] = i==j? 1.0: 0.0;


### PR DESCRIPTION
opencvのドキュメント(http://docs.opencv.org/2.4/modules/calib3d/doc/camera_calibration_and_3d_reconstruction.html#projectpoints)
で
> If the vector is NULL/empty, the zero distortion coefficients are assumed

と言われているように、distortionのパラメータがemptyだとzeroの配列と解釈されると説明されています。
これはemptyでも良い、とも取れますが、シミュレータなので明示的に[0, 0, 0, 0, 0]と入れて上げてもいいかもしれないです。

関連して、
https://github.com/ros-perception/vision_opencv/pull/82
のような変更を加えました。
また、　https://github.com/start-jsk/rtmros_common/issues/859#issuecomment-156593708
のような報告もありました。
