### PR TITLE
Pythonインタプリタにキーバインドを追加

### DIFF
--- a/src/PythonPlugin/PythonConsoleView.cpp
+++ b/src/PythonPlugin/PythonConsoleView.cpp
@@ -540,6 +540,17 @@ void PythonConsoleViewImpl::keyPressEvent(QKeyEvent* event)
         }
         break;
         
+    case Qt::Key_H:
+        if(event->modifiers() == Qt::ControlModifier){
+            if(textCursor().columnNumber() > inputColumnOffset){
+                QTextCursor cursor = textCursor();
+                cursor.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor, 1);
+                cursor.removeSelectedText();
+             }
+            done = true;
+        }
+        break;
+        
     case Qt::Key_Left:
     case Qt::Key_Backspace:
         if(textCursor().columnNumber() <= inputColumnOffset){

--- a/src/PythonPlugin/PythonConsoleView.cpp
+++ b/src/PythonPlugin/PythonConsoleView.cpp
@@ -524,6 +524,22 @@ void PythonConsoleViewImpl::keyPressEvent(QKeyEvent* event)
 
     switch(event->key()){
 
+    case Qt::Key_F:
+        if(event->modifiers() == Qt::ControlModifier){
+            moveCursor(QTextCursor::Right);
+            done = true;
+        }
+        break;
+        
+    case Qt::Key_B:
+        if(event->modifiers() == Qt::ControlModifier){
+            if(textCursor().columnNumber() > inputColumnOffset){
+                moveCursor(QTextCursor::Left);
+            }
+            done = true;
+        }
+        break;
+        
     case Qt::Key_Left:
     case Qt::Key_Backspace:
         if(textCursor().columnNumber() <= inputColumnOffset){
@@ -531,14 +547,36 @@ void PythonConsoleViewImpl::keyPressEvent(QKeyEvent* event)
         }
         break;
         
+    case Qt::Key_P:
+        if(event->modifiers() != Qt::ControlModifier){
+            break;
+        }
     case Qt::Key_Up:
         setInputString(getPrevHistoryEntry());
         done = true;
         break;
         
+    case Qt::Key_N:
+        if(event->modifiers() != Qt::ControlModifier){
+            break;
+        }
     case Qt::Key_Down:
         setInputString(getNextHistoryEntry());
         done = true;
+        break;
+        
+    case Qt::Key_A:
+        if(event->modifiers() == Qt::ControlModifier){
+            moveCursor(QTextCursor::StartOfLine);
+            for(int i=0; i < inputColumnOffset; ++i) moveCursor(QTextCursor::Right);
+            done = true;
+        }
+        break;
+        
+    case Qt::Key_E:
+        if( event->modifiers() == Qt::ControlModifier ){
+            moveCursor(QTextCursor::End);
+        }
         break;
         
     case Qt::Key_Return:


### PR DESCRIPTION
pythonインタプリタでいくつかのキーバインドを追加いたしまいした

- ctrl+p, ctrl+nで上矢印，下矢印に対応するコマンドヒストリの参照
- ctrl+f, ctrl+b, ctrl+a, ctrl+e でカーソルを左右，行頭行末へ移動
- ctrl+hでbackspace

ctrl+aはPR前はインタプリタ内の文字を全選択するようになっていましたが，一般的なpythonインタプリタでの挙動に合わせた方が良いかと思い，行頭への移動にoverwriteしました