### PR TITLE
fix compile error

### DIFF
--- a/src/RokiPlugin/RokiSimulatorItem.cpp
+++ b/src/RokiPlugin/RokiSimulatorItem.cpp
@@ -19,6 +19,7 @@
 #include <cnoid/BodyCollisionDetectorUtil>
 #include <cnoid/FloatingNumberString>
 #include <cnoid/EigenUtil>
+#include <cnoid/SceneDrawables>
 #include <cnoid/MeshExtractor>
 #include <cnoid/FileUtil>
 #include <boost/bind.hpp>


### PR DESCRIPTION
@fkanehiro さんからの依頼でRokiPluginをパッケージ化しているのですが、ENABLE_ROKIPLUGINするといくつかコンパイルエラーが出ています。

SgMeshのエラーについてはこのPRで修正しましたが、以下の部分の修正方法はわかっていません。

```
/home/yosuke/choreonoid/src/RokiPlugin/RokiSimulatorItem.cpp: In member function ‘void {anonymous}::RokiBody::updateForceSensors()’:
/home/yosuke/choreonoid/src/RokiPlugin/RokiSimulatorItem.cpp:772:44: error: ‘const class cnoid::DeviceList<cnoid::ForceSensor>’ has no member named ‘get’
         ForceSensor* sensor = forceSensors.get(i);
                                            ^
/home/yosuke/choreonoid/src/RokiPlugin/RokiSimulatorItem.cpp: In member function ‘bool cnoid::RokiSimulatorItemImpl::stepSimulation(const std::vector<cnoid::SimulationBody*>&)’:
/home/yosuke/choreonoid/src/RokiPlugin/RokiSimulatorItem.cpp:1059:35: error: ‘class cnoid::BasicSensorSimulationHelper’ has no member named ‘hasGyroOrAccelSensors’
         if(rokiBody->sensorHelper.hasGyroOrAccelSensors()){
                                   ^
/home/yosuke/choreonoid/src/RokiPlugin/RokiSimulatorItem.cpp:1060:36: error: ‘class cnoid::BasicSensorSimulationHelper’ has no member named ‘updateGyroAndAccelSensors’
             rokiBody->sensorHelper.updateGyroAndAccelSensors();
                                    ^
make[2]: *** [src/RokiPlugin/CMakeFiles/CnoidRokiPlugin.dir/RokiSimulatorItem.cpp.o] エラー 1
make[1]: *** [src/RokiPlugin/CMakeFiles/CnoidRokiPlugin.dir/all] エラー 2
make: *** [all] エラー 2
```
