### PR TITLE
Use proper PNG accessor functions instead of raw struct access

### DIFF
--- a/src/Util/ImageIO.cpp
+++ b/src/Util/ImageIO.cpp
@@ -183,7 +183,7 @@ void savePNG(const Image& image, const std::string& filename, bool isUpsideDown)
         throwSaveException(filename, strerror(errno));
     }
     
-    if(setjmp(png_ptr->jmpbuf)){
+    if(setjmp(png_jmpbuf(png_ptr))){
         png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
         fclose(fp);
         throwSaveException(filename, "Internal error.");


### PR DESCRIPTION
This fixes the compilation for recent versions of libpng (fix #78). That problem seems fairly common (see [that other project](https://github.com/Galapix/galapix/commit/833a6b4ba0649269e3c309aa2f3761b329d0c84d) for instance).