### PR TITLE
Fix SIGFPE in aspect ratio computation

### DIFF
--- a/src/Base/GLSceneRenderer.cpp
+++ b/src/Base/GLSceneRenderer.cpp
@@ -835,7 +835,7 @@ void GLSceneRenderer::setViewport(int x, int y, int width, int height)
 
 void GLSceneRendererImpl::setViewport(int x, int y, int width, int height)
 {
-    aspectRatio = (double)width / height;
+    if (height > 0) aspectRatio = (double)width / height;
     viewport << x, y, width, height;
     glViewport(x, y, width, height);
 }


### PR DESCRIPTION
While investigating `NaN`s in choreonoid, I found some unrelated issues in `GLSceneRenderer.cpp`, for instance this `0/0` in `setViewport`:

```txt
Program received signal SIGFPE, Arithmetic exception.
0x00007ffff78b7144 in cnoid::GLSceneRendererImpl::setViewport (this=0x555555a7ae50, x=0x0, y=0x0, width=0x0, height=0x0) at choreonoid/src/Base/GLSceneRenderer.cpp:838
838         aspectRatio = (double)width / height;
```
