### PR TITLE
add sginvariant node to set VRML def name even when the segment node …

### DIFF
--- a/src/Body/VRMLBodyLoader.cpp
+++ b/src/Body/VRMLBodyLoader.cpp
@@ -974,6 +974,10 @@ void VRMLBodyLoaderImpl::readSegmentNode(LinkInfo& iLink, VRMLProtoInstance* seg
             transform->setName(segmentNode->defName);
             iLink.visualShape->addChild(transform);
         }
+    } else {
+      node = new SgInvariantGroup;
+      node->setName(segmentNode->defName);
+      iLink.visualShape->addChild(node);
     }
 }
 


### PR DESCRIPTION
…is empty

fkanehiro/choreonoid-editor#22 の問題に対応するための変更です。

名前を保存したいだけのためにSgNodeを増やしてしまうことに若干の抵抗はあるのですが、実際はレンダラのキャッシュのところで消去されるので影響は少ないものと考えています。