### PR TITLE
add missing header Exception.h

### DIFF
--- a/src/Util/CMakeLists.txt
+++ b/src/Util/CMakeLists.txt
@@ -144,6 +144,7 @@ set(headers
   ExtJoystick.h
   Task.h
   AbstractTaskSequencer.h
+  Exception.h
   exportdecl.h
   Config.h
   )


### PR DESCRIPTION
SDKの利用に必要なヘッダが足りていなかったので加えました。