### PR TITLE
BodyMotion周りのpythonインターフェースを追加

### DIFF
--- a/src/Body/python/PyBodyModule.cpp
+++ b/src/Body/python/PyBodyModule.cpp
@@ -4,6 +4,7 @@
 
 #include "../Body.h"
 #include "../BodyLoader.h"
+#include "../BodyMotion.h"
 #include <cnoid/ValueTree>
 #include <cnoid/SceneGraph>
 #include <cnoid/PyUtil>
@@ -86,6 +87,13 @@ PyObject* Body_calcTotalMomentum(Body& self) {
 
 BodyPtr (BodyLoader::*BodyLoader_load2)(const std::string&) = &BodyLoader::load;
     
+MultiValueSeqPtr BodyMotion_get_jointPosSeq(BodyMotion& self) { return self.jointPosSeq(); }
+void BodyMotion_set_jointPosSeq(BodyMotion& self, const MultiValueSeqPtr& jointPosSeq) { self.jointPosSeq() = jointPosSeq; }
+MultiSE3SeqPtr BodyMotion_get_linkPosSeq(BodyMotion& self) { return self.linkPosSeq(); }
+void BodyMotion_set_linkPosSeq(BodyMotion& self, const MultiSE3SeqPtr& linkPosSeq) { self.linkPosSeq() = linkPosSeq; }
+
+BodyMotion::Frame (BodyMotion::*BodyMotion_frame)(int) = &BodyMotion::frame;
+
 } // namespace
 
 namespace cnoid 
@@ -228,6 +236,7 @@ BOOST_PYTHON_MODULE(Body)
             .def("hasVirtualJointForces", &Body::hasVirtualJointForces)
             .def("setVirtualJointForces", &Body::setVirtualJointForces)
             .def("addCustomizerDirectory", &Body::addCustomizerDirectory).staticmethod("addCustomizerDirectory")
+            .def(other<BodyMotion::Frame>() >> self)
             ;
 
         enum_<Body::ExtraJointType>("ExtraJointType")
@@ -250,6 +259,34 @@ BOOST_PYTHON_MODULE(Body)
         .def("load", BodyLoader_load2)
         .def("lastActualBodyLoader", &BodyLoader::lastActualBodyLoader)
         ;
+
+    {
+        scope bodyMotionScope =
+            class_< BodyMotion, BodyMotionPtr, bases<AbstractMultiSeq> >("BodyMotion")
+            .def("setNumParts", &BodyMotion::setNumParts)
+            .def("getNumParts", &BodyMotion::getNumParts)
+            .def("numJoints", &BodyMotion::numJoints)
+            .def("numLings", &BodyMotion::numLinks)
+            .def("frameRate", &BodyMotion::frameRate)
+            .def("getFrameRate",&BodyMotion::getFrameRate)
+            .def("setFrameRate", &BodyMotion::setFrameRate)
+            .def("getOffsetTimeFrame", &BodyMotion::getOffsetTimeFrame)
+            .def("numFrames", &BodyMotion::numFrames)
+            .def("getNumFrames", &BodyMotion::getNumFrames)
+            .def("setNumFrames", &BodyMotion::setNumFrames)
+            .add_property("jointPosSeq", BodyMotion_get_jointPosSeq, BodyMotion_set_jointPosSeq)
+            .add_property("linkPosSeq", BodyMotion_get_linkPosSeq, BodyMotion_set_linkPosSeq)
+            .def("frame", BodyMotion_frame)
+            ;
+
+        class_< BodyMotion::Frame >("Frame", no_init)
+            .def("frame", &BodyMotion::Frame::frame)
+            .def(self << other<Body>())
+            .def(other<Body>() >> self)
+            ;
+    }
+
+    implicitly_convertible<BodyMotionPtr, AbstractMultiSeqPtr>();
 
 #ifdef _MSC_VER    
 	register_ptr_to_python<BodyPtr>();

--- a/src/Util/python/PyUtilModule.cpp
+++ b/src/Util/python/PyUtilModule.cpp
@@ -5,9 +5,20 @@
 #include "PyUtil.h"
 #include "../ExecutablePath.h"
 #include "../FloatingNumberString.h"
+#include "../Deque2D.h"
 
 using namespace boost::python;
 using namespace cnoid;
+
+namespace
+{
+
+typedef Deque2D< double, std::allocator<double> > Deque2DDouble;
+void Deque2DDouble_Row_setitem(Deque2DDouble::Row& self, const int i, const double x) { self[i] = x; }
+double& (Deque2DDouble::Row::*Row_getitem)(int) = &Deque2DDouble::Row::operator[];
+const double& (Deque2DDouble::Row::*Row_getitem_const)(int) const = &Deque2DDouble::Row::operator[];
+
+}
 
 namespace cnoid {
 
@@ -45,4 +56,12 @@ BOOST_PYTHON_MODULE(Util)
         .def("setPositiveValue", &FloatingNumberString::setPositiveValue)
         .def("setNonNegativeValue", &FloatingNumberString::setNonNegativeValue)
         .def("value", &FloatingNumberString::value);
+
+    class_<Deque2DDouble::Row>("Row", init<>())
+        .def("size", &Deque2DDouble::Row::size)
+        .def("at", &Deque2DDouble::Row::at, return_value_policy<copy_non_const_reference>())
+        .def("__getitem__", Row_getitem, return_value_policy<return_by_value>())
+        .def("__getitem__", Row_getitem_const, return_value_policy<return_by_value>())
+        .def("__setitem__", Deque2DDouble_Row_setitem)
+        ;
 }


### PR DESCRIPTION
```
bodyMotion->frame(i) >> *body;
```
や
```
MultiValueSeq::Frame q = motion->jointPosSeq()->frame(i);
q[10] = 20.0;
```
のような操作をpythonから行いたかったのでBodyMotion周りでpythonインターフェースを追加してみました

ただし，MultiValueSeq::Frameクラスを取得するときにDeque2D＜double＞::Rowを作る必要があり，その辺りで少し不都合があるかもしれません．
c++での参照関係が
- MultiValueSeq
  - MultiSeq＜double＞
    - Deque2D ＜double, std::allocator＜double＞＞
    - AbstractMultiSeq

となっているところを
[Util/python/PySeqTypes.cpp L.81](https://github.com/s-nakaoka/choreonoid/blob/master/src/Util/python/PySeqTypes.cpp#L81)で
pythonでは
- MultiValueSeq
  - AbstractMultiSeq

となっていてDeque2Dを継承していないことになってる？ところにDeque2D＜double＞::Rowを実装してしまっています
(jointPosSeq()->frame(i)を呼ぶと最終的にDeque2D::Rowが返ってきてしまうので．．．)

motion->jointPosSeq()->frame(i)を呼ぶ分には問題ない様ですが，その他の場合に何か不都合がありますでしょうか?