### PR TITLE
fix vrml writing of sensor nodes

### DIFF
--- a/src/Body/VRMLBodyWriter.cpp
+++ b/src/Body/VRMLBodyWriter.cpp
@@ -199,10 +199,8 @@ void VRMLBodyWriter::writeForceSensorNode(VRMLNodePtr node)
     if(sensor->sensorId >= 0){
         out << indent << "sensorId " << sensor->sensorId << "\n";
     }
-    out << indent << "maxForce\n";
-    writeMFValues(sensor->maxForce, 3);
-    out << indent << "maxTorque\n";
-    writeMFValues(sensor->maxTorque, 3);
+    out << indent << "maxForce " << sensor->maxForce << "\n";
+    out << indent << "maxTorque " << sensor->maxTorque << "\n";
 
     endNode();
 }
@@ -219,8 +217,7 @@ void VRMLBodyWriter::writeGyroNode(VRMLNodePtr node)
     if(sensor->sensorId >= 0){
         out << indent << "sensorId " << sensor->sensorId << "\n";
     }
-    out << indent << "maxAngularVelocity\n";
-    writeMFValues(sensor->maxAngularVelocity, 3);
+    out << indent << "maxAngularVelocity " << sensor->maxAngularVelocity << "\n";
 
     endNode();
 }
@@ -237,8 +234,7 @@ void VRMLBodyWriter::writeAccelerationSensorNode(VRMLNodePtr node)
     if(sensor->sensorId >= 0){
         out << indent << "sensorId " << sensor->sensorId << "\n";
     }
-    out << indent << "maxAcceleration\n";
-    writeMFValues(sensor->maxAcceleration, 3);
+    out << indent << "maxAcceleration " << sensor->maxAcceleration << "\n";
 
     endNode();
 }

--- a/src/Util/STLSceneLoader.cpp
+++ b/src/Util/STLSceneLoader.cpp
@@ -41,7 +41,8 @@ SgNode* STLSceneLoader::load(const std::string& fileName)
 
     uint8_t header[80];
     ifs.read((char *)header, 80);
-    if(strncmp((char *)header, "solid", 5) != 0){
+    if(strncmp((char *)header, "solid", 5) != 0 ||
+       header[0] == 's' && header[1] == 'o' && header[2] == 'l' && header[3] == 'i' && header[4] == 'd'){
         // stl file is in binary format
         uint32_t ntriangle;
         ifs.read((char *)&ntriangle, 4);


### PR DESCRIPTION
前回お送りしたセンサノードのVRML出力フォーマットが一部間違っていたので修正しました。