### PR TITLE
BodyPlugin(python): add python interface for setForcedPosition and clearForcedPositions

### DIFF
--- a/src/BodyPlugin/python/PySimulationClasses.cpp
+++ b/src/BodyPlugin/python/PySimulationClasses.cpp
@@ -79,6 +79,8 @@ void exportSimulationClasses()
         .def("setAllLinkPositionOutputMode", &SimulatorItem::setAllLinkPositionOutputMode)
         .def("setExternalForce", &SimulatorItem::setExternalForce, SimulatorItem_setExternalForce_overloads())
         .def("clearExternalForces", &SimulatorItem::clearExternalForces)
+        .def("setForcedPosition", &SimulatorItem::setForcedPosition)
+        .def("clearForcedPositions", &SimulatorItem::clearForcedPositions)
         ;
     {
         scope simulatorItemScope = simulatorItemClass;


### PR DESCRIPTION
シミュレータのロボットの位置を動かすためのpythonインタープリタを追加しました．
#103 のpython版にあたるものです

simulatorItem.setForcedPosition(<BodyItem>,<numpy.array>)
でロボットの位置が強制的に動いて，
simulatorItem.clearForcedPositions()
で強制保持が解除されると思います

もし，問題がなければマージしていただけると幸いです
宜しくお願い致します