### PR TITLE
[src/Body/python/PyBodyModule.cpp] cnoid::Deviceのpythonインターフェイスを追加

### DIFF
--- a/src/Body/python/PyBodyModule.cpp
+++ b/src/Body/python/PyBodyModule.cpp
@@ -114,6 +114,12 @@ void BodyMotion_set_linkPosSeq(BodyMotion& self, const MultiSE3SeqPtr& linkPosSe
 
 BodyMotion::Frame (BodyMotion::*BodyMotion_frame)(int) = &BodyMotion::frame;
 
+DevicePtr Device_clone(Device& self) { return self.clone(); }
+void Device_clearState(Device& self) { return self.clearState(); }
+LinkPtr Device_link(Device& self) { return self.link(); }
+Position Device_get_T_local(Device& self) { return (Position) self.T_local(); }
+void Device_set_T_local(Device& self, const Position& T_local) { self.T_local() = T_local.matrix(); }
+
 } // namespace
 
 namespace cnoid 
@@ -329,6 +335,24 @@ BOOST_PYTHON_MODULE(Body)
     }
 
     implicitly_convertible<BodyMotionPtr, AbstractMultiSeqPtr>();
+
+    {
+      scope deviceScope =
+        class_< Device, DevicePtr, boost::noncopyable >("Device", no_init)
+        .def("setIndex", &Device::setIndex)
+        .def("setId", &Device::setId)
+        .def("setName", &Device::setName)
+        .def("setLink", &Device::setLink)
+        .def("clone", &Device_clone)
+        .def("clearState", &Device_clearState)
+        .def("hasStateOnly", &Device::hasStateOnly)
+        .def("index", &Device::index)
+        .def("id", &Device::id)
+        .def("name", &Device::name, return_value_policy<copy_const_reference>())
+        .def("link", &Device_link)
+        .add_property("T_local", Device_get_T_local, Device_set_T_local)
+        ;
+    }
 
 #ifdef _MSC_VER
     register_ptr_to_python<BodyPtr>();


### PR DESCRIPTION
choreonoidでいつもお世話になっております。
東京大学情報システム工学研究室の小山と申します。
よろしくお願いいたします。

cnoid::Deviceのpythonインターフェイスを追加しました。

cnoid::Device::T_localの返り値の型がIsometry3で、こちらのpythonのconverterが提供されていないので、Positionにキャストしております。
https://github.com/s-nakaoka/choreonoid/commit/658d497471e6ff9e74862d2ea49fc3a31627333b#diff-642ec0c3fd6b1c94d32ff253dbea0908R120

Isometry3については、以下の部分で、
> // The followings should be removed later

となっていたので、Positionへのキャストとしたのですが、他の方法がよろしければ、ご教示ください。
https://github.com/s-nakaoka/choreonoid/blob/master/src/Util/EigenTypes.h#L75-L78

どうぞよろしくお願いいたします。

