### PR TITLE
add Dockerfile and travis.yml to test compilation using clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: trusty
+sudo: required
+
+services:
+  - docker
+
+env:
+  matrix:
+    - TARGET_ENVIRONMENT=ubuntu-xenial-gcc
+    - TARGET_ENVIRONMENT=ubuntu-xenial-clang
+
+script:
+  - docker build --rm -t ${TARGET_ENVIRONMENT} -f misc/docker/Dockerfile-${TARGET_ENVIRONMENT} .

--- a/misc/docker/Dockerfile-ubuntu-xenial-clang
+++ b/misc/docker/Dockerfile-ubuntu-xenial-clang
@@ -1,0 +1,16 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && \
+    apt-get install -y sudo clang && \
+    apt-get clean
+
+ENV CC /usr/bin/clang
+ENV CXX /usr/bin/clang++
+
+ADD . /choreonoid
+
+RUN cd choreonoid && \
+    echo "y" | ./misc/script/install-requisites-ubuntu-16.04.sh && \
+    cmake . && \
+    make && \
+    make install

--- a/misc/docker/Dockerfile-ubuntu-xenial-gcc
+++ b/misc/docker/Dockerfile-ubuntu-xenial-gcc
@@ -1,0 +1,13 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && \
+    apt-get install -y sudo && \
+    apt-get clean
+
+ADD . /choreonoid
+
+RUN cd choreonoid && \
+    echo "y" | ./misc/script/install-requisites-ubuntu-16.04.sh && \
+    cmake . && \
+    make && \
+    make install


### PR DESCRIPTION
C++テンプレートを多用するコードをgccでコンパイルすると遅いのでclangを使いたいなと思っているのですが、今のバージョンはclangだとコンパイルできないようです。

もし原因がわかったら解決策もPRで送りたいと思っていますが、まずはチェックするための環境を送ります。

travis-ciでフリーのアカウントを登録してレポジトリを有効化しておくと以下のような検証がコミット毎に出てきます。

https://travis-ci.org/yosuke/choreonoid
