### PR TITLE
Add std-c++11 cflags to pkg-config files

### DIFF
--- a/misc/pkgconfig/choreonoid-base.pc.in
+++ b/misc/pkgconfig/choreonoid-base.pc.in
@@ -14,4 +14,4 @@ Version: @CNOID_FULL_VERSION@
 Requires: choreonoid-util = @CNOID_FULL_VERSION@ @PKGCONFIG_QT_REQUIREMENTS@
 Conflicts:
 Libs: -L${plugindir} -lCnoidBase
-Cflags: -DQT_NO_KEYWORDS
+Cflags: -DQT_NO_KEYWORDS -std=c++11

--- a/misc/pkgconfig/choreonoid-body-plugin.pc.in
+++ b/misc/pkgconfig/choreonoid-body-plugin.pc.in
@@ -16,3 +16,4 @@ Version: @CNOID_FULL_VERSION@
 Requires: choreonoid-base = @CNOID_FULL_VERSION@ choreonoid-body = @CNOID_FULL_VERSION@
 Conflicts:
 Libs: -lCnoidBodyPlugin
+Cflags: -std=c++11

--- a/misc/pkgconfig/choreonoid-body.pc.in
+++ b/misc/pkgconfig/choreonoid-body.pc.in
@@ -16,3 +16,4 @@ Version: @CNOID_FULL_VERSION@
 Requires: choreonoid-util = @CNOID_FULL_VERSION@
 Conflicts:
 Libs: -lCnoidBody
+Cflags: -std=c++11

--- a/misc/pkgconfig/choreonoid-util.pc.in
+++ b/misc/pkgconfig/choreonoid-util.pc.in
@@ -13,4 +13,4 @@ Version: @CNOID_FULL_VERSION@
 Requires: @PKGCONFIG_EIGEN_REQUIREMENT@
 Conflicts:
 Libs: -L${libdir} -lCnoidUtil -lboost_filesystem -lboost_system
-Cflags: -I${includedir}
+Cflags: -I${includedir} -std=c++11


### PR DESCRIPTION
はじめまして、JSKのM1のグエンキムゴックカンと申します。

ロボットのControllerを作成しています。
choreonoidの外部プラグインと同様にHeaderファイルを参照してchoreonoid本体と別にビルドしているのですが、
以下のようなエラーが出ます。
```
/usr/local/choreonoid/include/choreonoid-1.7/cnoid/src/Body/BodyCustomizerInterface.h: In constructor ‘cnoid::BodyCustomizerInterface::BodyCustomizerInterface()’:
/usr/local/choreonoid/include/choreonoid-1.7/cnoid/src/Body/BodyCustomizerInterface.h:67:29: error: ‘nullptr’ was not declared in this scope
         getTargetModelNames(nullptr),
```
最近、choreonoid-1.7にアップデートしておりまして、std=c++11を設定すると、このエラーが解消されます。
pkg-configファイルにcflagsの情報を追加するのが正しいでしょうか。

環境はUbuntu 14.04 です