### PR TITLE
add SceneWidgetEvent.h to headers

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -188,6 +188,7 @@ set(headers
   LazySignal.h
   LazyCaller.h
   SceneWidget.h
+  SceneWidgetEvent.h
   SceneProjector.h
   SceneDragProjector.h
   SceneDragger.h


### PR DESCRIPTION
外部プラグインにおいてinclude<cnoid/RectRegionMarker>とするとSceneWidgetEvent.hが見つからないとエラーが出ました．

SceneWidgetEvent.hがinstall時で入れるべきファイルリストから抜けているようでしたので
set( headers ...
でSceneWidgetEvent.hを追加しました．