### PR TITLE
Implement ABS_ACCELERATION

### DIFF
--- a/src/OpenRTMPlugin/deprecated/VirtualRobotPortHandler.cpp
+++ b/src/OpenRTMPlugin/deprecated/VirtualRobotPortHandler.cpp
@@ -212,6 +212,20 @@ void LinkDataOutPortHandler::inputDataFromSimulator(BodyRTCItem* bodyRTC)
         }
     }
     break;
+    case ABS_ACCELERATION:
+    {
+        value.data.length(6*n);
+        for(size_t i=0, j=0; i<n; i++){
+            Link* link = body->link(linkNames[i]);
+            value.data[j++] = link->dv()(0);
+            value.data[j++] = link->dv()(1);
+            value.data[j++] = link->dv()(2);
+            value.data[j++] = link->dw()(0);
+            value.data[j++] = link->dw()(1);
+            value.data[j++] = link->dw()(2);
+        }
+    }
+    break;
     case EXTERNAL_FORCE:
     {
         value.data.length(6*n);


### PR DESCRIPTION
I needed to access the robot's floating base acceleration (linear and angular) from the simulation. Seems like `ABS_ACCELERATION`was not defined, here is a working implementation.
Is this the proper way to achieve this?

I then use it as follow
```
out-port = waistAbsAcceleration:WAIST:ABS_ACCELERATION
```
And connect the correcponding port to my component.