### PR TITLE
Poseへの接触点情報の追加

### DIFF
--- a/src/PoseSeqPlugin/Pose.h
+++ b/src/PoseSeqPlugin/Pose.h
@@ -78,9 +78,11 @@ public:
         bool isStationaryPoint() const { return isStationaryPoint_; }
         bool isTouching() const { return isTouching_; }
         const Vector3& partingDirection() const { return partingDirection_; }
-        void setTouching(const Vector3& partingDirection) {
+        const std::vector<Vector3>& contactPoints() const { return contactPoints_; }
+        void setTouching(const Vector3& partingDirection, const std::vector<Vector3>& contactPoints) {
             isTouching_ = true;
             partingDirection_ = partingDirection;
+            contactPoints_ = contactPoints;
         }
         void clearTouching() { isTouching_ = false; }
         bool isSlave() const { return isSlave_; }
@@ -92,6 +94,7 @@ public:
         bool isTouching_;
         bool isSlave_;
         Vector3 partingDirection_;
+        std::vector<Vector3> contactPoints_;
         friend class Pose;
     };
 

--- a/src/PoseSeqPlugin/PoseFilters.cpp
+++ b/src/PoseSeqPlugin/PoseFilters.cpp
@@ -282,7 +282,9 @@ bool FlipFilter::flipPose(PosePtr pose)
         }
         info->setStationaryPoint(orgInfo.isStationaryPoint());
         if(orgInfo.isTouching()){
-            info->setTouching(orgInfo.partingDirection());
+            std::vector<Vector3> contactPoints = orgInfo.contactPoints();
+            for(auto& pointVector : contactPoints) pointVector.y() *= -1;
+            info->setTouching(orgInfo.partingDirection(), contactPoints);
         }
         info->setSlave(orgInfo.isSlave());
 

--- a/src/PoseSeqPlugin/PoseSeqItem.cpp
+++ b/src/PoseSeqPlugin/PoseSeqItem.cpp
@@ -297,7 +297,7 @@ bool PoseSeqItem::convertSub(BodyPtr orgBody, const Mapping& convInfo)
                         linkInfo->R = orgLinkInfo.R;
                         linkInfo->setStationaryPoint(orgLinkInfo.isStationaryPoint());
                         if(orgLinkInfo.isTouching()){
-                            linkInfo->setTouching(orgLinkInfo.partingDirection());
+                            linkInfo->setTouching(orgLinkInfo.partingDirection(), orgLinkInfo.contactPoints());
                         }
                         linkInfo->setSlave(orgLinkInfo.isSlave());
                         if(orgLinkInfo.isBaseLink()){

--- a/src/PoseSeqPlugin/PoseSeqViewBase.cpp
+++ b/src/PoseSeqPlugin/PoseSeqViewBase.cpp
@@ -1644,23 +1644,25 @@ bool PoseSeqViewBase::setCurrentLinkStateToIkLink(Link* link, Pose::LinkInfo* li
         updated = true;
     }
     
-    bool collided = false;
+    std::vector<Vector3> contactPoints;
     const std::vector<CollisionLinkPairPtr>& collisions = currentBodyItem->collisionsOfLink(link->index());
     for(size_t i=0; i < collisions.size(); ++i){
         if(!collisions[i]->isSelfCollision()){
-            collided = true;
-            break;
+            CollisionLinkPair& collisionPair = *collisions[i];
+            for(std::vector<Collision>::iterator iter = collisionPair.collisions.begin(); iter != collisionPair.collisions.end(); ++iter){
+                contactPoints.push_back(link->R().transpose()*(iter->point - link->p()));
+            }
         }
     }
 
-    if(collided){
+    if(contactPoints.size() > 0){
         /**
            \todo set a parting direction correctly
            (now it is assumed that the touching only happens for the flat and level floor).
         */
         Vector3 partingDirection(0.0, 0.0, 1.0);
-        if(!linkInfo->isTouching() || linkInfo->partingDirection() != partingDirection){
-            linkInfo->setTouching(partingDirection);
+        if(!linkInfo->isTouching() || linkInfo->partingDirection() != partingDirection || linkInfo->contactPoints() != contactPoints){
+            linkInfo->setTouching(partingDirection, contactPoints);
             updated = true;
         }
     } else {


### PR DESCRIPTION
Pose::LinkInfoとPoseSeqファイルに接触リンクの接触点に関する情報を追加しました

コミットの概要は以下のようになっています

- LinkInfoのcontacttPoints_メンバ変数に接触点群が保持されます
  - 各接触点は接触リンク固定座標系で表現されています
- PoseSeqファイルにはikLinkInfo内にcontactPointsというキーで点のリストが保存されます
- PoseSeqViewBase::setCurrentLinkStateToIkLink関数でcollidedというbool変数を削除し，代わりにcontactPoints(std::vector)のサイズでリンクが接触しているどうかを判断しています．その際に一つのリンクが複数の物体と干渉する際にbreak文は不都合なので削除しました
