### PR TITLE
fix SimulationBody constructor in PhysXBody constructor

### DIFF
--- a/src/PhysXPlugin/PhysXSimulatorItem.cpp
+++ b/src/PhysXPlugin/PhysXSimulatorItem.cpp
@@ -709,7 +709,7 @@ void PhysXLink::setVelocityToPhysX()
 
 
 PhysXBody::PhysXBody(const Body& orgBody)
-    : SimulationBody(new Body(orgBody))
+    : SimulationBody(orgBody.clone())
 {
     pxAggregate = 0;
     extraJoints.clear();


### PR DESCRIPTION
fix PhysXBody constructor
related to https://github.com/s-nakaoka/choreonoid/pull/223
cloneすれば内部でnewが行われるという理解のもと，コンストラクタを変更しました．