### PR TITLE
debug calcAngularMomentumJacobian

### DIFF
--- a/src/Body/Jacobian.cpp
+++ b/src/Body/Jacobian.cpp
@@ -215,7 +215,8 @@ void calcAngularMomentumJacobian(Body* body, Link* base, Eigen::MatrixXd& H)
 
     if(!base){
         const int c = nj;
-        H.block(0, c, 3, 3).setIdentity();
+        H.block(0, c, 3, 3).setZero();
+        H.block(0, c+3, 3, 3) = subMasses[rootLink->index()].Iw;
 
         Vector3 cm = body->calcCenterOfMass();
         Matrix3d cm_cross;
@@ -223,7 +224,7 @@ void calcAngularMomentumJacobian(Body* body, Link* base, Eigen::MatrixXd& H)
             0.0,  -cm(2), cm(1),
             cm(2),    0.0,  -cm(0),
             -cm(1), cm(0),    0.0;
-        H -= cm_cross * M;
+        H.block(0,0,3,c) -= cm_cross * M;
 
     }
     


### PR DESCRIPTION
角運動量ヤコビアンの計算が一部間違えていたので修正しました
確認として十分かどうかはわかりませんが，cnoid::Body::calcTotalMomentumの値を重心周りの角運動量に変換したものと値を比較して一致していることをいくつかの値で確認しました．

ここの実装は梶田先生の「分解運動量制御：運動量と角運動量に基づく ヒューマノイドロボットの全身運動生成」(10.7210/jrsj.22.772)の実装だと思いますが，

https://github.com/s-nakaoka/choreonoid/compare/master...kindsenior:PR-debug-angular-momentum-jacobian?expand=1#diff-fd82b28660151305f3fdfd1687a3aa32L218
の変更が式(1)のI~に対応していて，

https://github.com/s-nakaoka/choreonoid/compare/master...kindsenior:PR-debug-angular-momentum-jacobian?expand=1#diff-fd82b28660151305f3fdfd1687a3aa32L226
の変更が式(22)に対応すると思います