### PR TITLE
modify python interface for Body

### DIFF
--- a/src/Body/pybind11/PyBodyModule.cpp
+++ b/src/Body/pybind11/PyBodyModule.cpp
@@ -41,6 +41,7 @@ PYBIND11_MODULE(Body, m)
         ;
 
     py::class_<BodyLoader, AbstractBodyLoader>(m, "BodyLoader")
+        .def(py::init<>())
         .def("load", (Body*(BodyLoader::*)(const string&))&BodyLoader::load)
         .def("lastActualBodyLoader", &BodyLoader::lastActualBodyLoader)
         ;

--- a/src/Body/pybind11/PyBodyModule.cpp
+++ b/src/Body/pybind11/PyBodyModule.cpp
@@ -48,6 +48,7 @@ PYBIND11_MODULE(Body, m)
 
     py::class_<JointPath, shared_ptr<JointPath>>(m, "JointPath")
         .def(py::init<>())
+        .def_static("getCustomPath", &JointPath::getCustomPath)
         .def_property_readonly("numJoints", &JointPath::numJoints)
         .def("joint", &JointPath::joint)
         .def_property_readonly("baseLink", &JointPath::baseLink)

--- a/src/Body/pybind11/PyBodyModule.cpp
+++ b/src/Body/pybind11/PyBodyModule.cpp
@@ -56,7 +56,7 @@ PYBIND11_MODULE(Body, m)
         .def("indexOf", &JointPath::indexOf)
         .def("customizeTarget", &JointPath::customizeTarget)
         .def_property_readonly("numIterations", &JointPath::numIterations)
-        .def("calcJacobian", &JointPath::calcJacobian)
+        .def("calcJacobian", [](JointPath& self, Eigen::Ref< Eigen::Matrix<double, -1, -1, Eigen::RowMajor> > out_J){ MatrixXd J; self.calcJacobian(J); out_J = J; })
         .def("calcInverseKinematics", (bool(JointPath::*)())&JointPath::calcInverseKinematics)
         .def("calcInverseKinematics", (bool(JointPath::*)(const Position&))&JointPath::calcInverseKinematics)
 


### PR DESCRIPTION
以下の3つの変更です

- Body* BodyLoader::load(const std::string& filename) をpythonから呼び出すためにBodyLoaderのコンストラクタのpythonインターフェイスを追加しました
- inline std::shared_ptr<JointPath> getCustomJointPath(Body* body, Link* baseLink, Link* endLink)がdeprecated なので static std::shared_ptr<JointPath> JointPath::getCustomPath(Body* body, Link* baseLink, Link* endLink) を呼び出すためのpythonインターフェイスを追加しました
- void calcJacobian(Eigen::MatrixXd& out_J)をpythonから呼び出すとout_Jの行列が参照渡しされていなかったので修正しました．
以前のコードだと以下のpythonの呼び出し方法ではヤコビアンが取得できず値が初期値のままでした．
```
from cnoid import Body, Base, BodyPlugin
body = Base.ItemTreeView.instance.selectedItem(BodyPlugin.BodyItem).body
jp = Body.getCustomJointPath(body, body.rootLink, body.link("joint name"))
J = numpy.ndarray((6,jp.numJoints))
jp.calcJacobian(J)
```
https://pybind11.readthedocs.io/en/stable/advanced/cast/eigen.html#pass-by-reference
によるとEigen::Refを用いる今回の修正で正しいような気はするのですが，以前のコードでも参照渡しできていたような記憶があるので使い方等を間違えているようでしたらご指摘いただけると幸いです

あと懸念事項としては，データ保持形式がEigen(Column Major)とnumpy(Row Major)で異なっていた(https://pybind11.readthedocs.io/en/stable/advanced/cast/eigen.html#storage-orders) ので，pythonからアクセスするときだけEigenをRow Majorに変換するようにしていますが，こちらもpythonから`J = np.ndarray((6,6), order='F')`などすれば不要ではあるので実装方法は要検討かもしれません．

