### PR TITLE
Use a default format when loading a body item

### DIFF
--- a/src/Base/Archive.cpp
+++ b/src/Base/Archive.cpp
@@ -255,12 +255,15 @@ bool Archive::loadFileTo(Item* item) const
 }
 
 
-bool Archive::loadItemFile(Item* item, const std::string& fileNameKey, const std::string& fileFormatKey) const
+bool Archive::loadItemFile(Item* item, const std::string& fileNameKey, const std::string& fileFormatKey, const std::string & defaultFormat) const
 {
     string filename, format;
     if(readRelocatablePath(fileNameKey, filename)){
         if(!fileFormatKey.empty()){
             read(fileFormatKey, format);
+            if(format.empty()){
+              format = defaultFormat;
+            }
         }
         return item->load(filename, currentParentItem(), format, this);
     }

--- a/src/Base/Archive.h
+++ b/src/Base/Archive.h
@@ -69,7 +69,7 @@ public:
     bool readRelocatablePath(const std::string& key, std::string& out_value) const;
     bool loadFileTo(Item* item) const;
     //! \deprecated
-    bool loadItemFile(Item* item, const std::string& fileNameKey, const std::string& fileFormatKey = std::string()) const;
+    bool loadItemFile(Item* item, const std::string& fileNameKey, const std::string& fileFormatKey = std::string(), const std::string & defaultFormat = std::string()) const;
     
     std::string getRelocatablePath(const std::string& path) const;
     bool writeRelocatablePath(const std::string& key, const std::string& path);

--- a/src/BodyPlugin/BodyItem.cpp
+++ b/src/BodyPlugin/BodyItem.cpp
@@ -1788,7 +1788,10 @@ bool BodyItem::Impl::restore(const Archive& archive)
         archive.loadFileTo(self);
     } else {
         // for the backward compatibiliy
-        archive.loadItemFile(self, "modelFile", "format");
+        if(!archive.loadItemFile(self, "modelFile", "format", "CHOREONOID-BODY"))
+        {
+          return false;
+        }
     }
 
     Vector3 p = Vector3::Zero();


### PR DESCRIPTION
This PR sets a default format when loading a body item that doesn't have a format entry.

It might be the wrong place to handle this but I'm not sure where/when the format entry is used within the `BodyItem` class