### PR TITLE
Make VRML parser locale-free

### DIFF
--- a/src/Util/strtofloat.h
+++ b/src/Util/strtofloat.h
@@ -2,21 +2,14 @@
 // This is neccessary because the implementation of VC++6.0 uses 'strlen()' in the function,
 // so that it becomes too slow for a string buffer which has long length.
 
+#include <cctype>
+#include <cmath>
+
 namespace cnoid {
 
-#ifndef _MSC_VER
-
-#include <cstdlib>
-inline float strtof(const char* nptr, char** endptr){
-    return std::strtof(nptr, endptr);
-}
-inline double strtod(const char* nptr, char** endptr){
-    return std::strtod(nptr, endptr);
-}
-
-#else
-
-template<typename T> T strtofloat(const char* nptr, char** endptr)    
+// Replacement for 'strtod()' function
+// This is necessary for a locale-free version
+template<typename T> T strtofloat(const char* nptr, char** endptr)
 {
     const char* org = nptr;
     bool valid = false;
@@ -29,24 +22,24 @@ template<typename T> T strtofloat(const char* nptr, char** endptr)
         sign = -1.0;
         nptr++;
     }
-    if(isdigit((unsigned char)*nptr)){
+    if(std::isdigit((unsigned char)*nptr)){
         valid = true;
         do {
             value = value * 10.0 + (*nptr - '0');
             nptr++;
-        } while(isdigit((unsigned char)*nptr));
+        } while(std::isdigit((unsigned char)*nptr));
     }
     if(*nptr == '.'){
         //valid = false; // allow values which end with '.'. For example, "0."
         nptr++;
-        if(isdigit((unsigned char)*nptr)){
+        if(std::isdigit((unsigned char)*nptr)){
             T small = 0.1;
             valid = true;
             do {
                 value += small * (*nptr - '0');
                 small *= 0.1;
                 nptr++;
-            } while(isdigit((unsigned char)*nptr));
+            } while(std::isdigit((unsigned char)*nptr));
         }
     }
     if(valid && (*nptr == 'e' || *nptr == 'E')){
@@ -59,13 +52,13 @@ template<typename T> T strtofloat(const char* nptr, char** endptr)
             psign = -1.0;
             nptr++;
         }
-        if(isdigit((unsigned char)*nptr)){
+        if(std::isdigit((unsigned char)*nptr)){
             valid = true;
             T p = 0.0;
             do {
                 p = p * 10.0 + (*nptr - '0');
                 nptr++;
-            } while(isdigit((unsigned char)*nptr));
+            } while(std::isdigit((unsigned char)*nptr));
             value *= pow(10.0, (double)(psign * p));
         }
     }
@@ -82,6 +75,5 @@ inline float strtof(const char* nptr, char** endptr) {
 inline double strtod(const char* nptr, char** endptr) {
     return strtofloat<double>(nptr, endptr);
 }
-#endif
 
 }


### PR DESCRIPTION
The VRML loader fails to parse floating point numbers when the locale is using coma-separated numbers instead of dot-separated numbers. I ran into this issue in the past, and this was brought back to my attention yesterday my two independant german users (the official separators for decimal points is the coma in german).

See for the original issue: https://github.com/jrl-umi3218/lipm_walking_controller/issues/14#issuecomment-658695844

This is the same problem that Pierre reported a while ago for openhrp3: https://github.com/fkanehiro/openhrp3/pull/144.
I applied the same solution here:

> ultimately using the strtod function. Howver, strtod is locale-dependent so this PR avoids calling it. This is already the case on Windows (for other reasons) so I'm just re-using the Windows implementation for every platform.

To test this you can run with a german locale (assuming you have german locales installed) on any simulation that loads VRML files with floating-point numbers. It should fail with the current master and succeed with the patch.
```
LC_ALL="" LC_NUMERIC="de_DE.UTF-8" choreonoid simulation.cnoid
```


However, on my machine, running the above commands leads to a fully working simulation, but the "Scene" view is completely black and I cannot see the robots (it works fine with english locale). This bug happens even without this patch, but just briefly looking at the code, I could not understand why this would happen. I think Niels had a similar issue on his laptop (I'll forward this issue to him too).